### PR TITLE
Pin wxpython to prevent weird wheel errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-anvil==0.0.2
 anvil_parser==0.9.0
 wxpython==4.1.0
 Gooey==1.0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 anvil==0.0.2
 anvil_parser==0.9.0
+wxpython==4.1.0
 Gooey==1.0.8.1


### PR DESCRIPTION
Also remove anvil from requirements.txt, since you actually want to use the anvil defined by anvil_parser instead